### PR TITLE
Missing package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
     "grunt": "^1.0",
     "grunt-contrib-jshint": "^1.1",
     "grunt-contrib-uglify": "^2.3"
-  }
+  },
+  "version": "1.0.0"
 }


### PR DESCRIPTION
$ npm i github:neveldo/mapael-maps#1.0.0
npm ERR! Can't install github:neveldo/mapael-maps#4414fe913d1c294f609937e8d0cee41321cd2b94: Missing package version